### PR TITLE
feat(obfuscation): add Amnezia tag range support for packet types H1–H4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "mock_instant",
  "nix",
  "parking_lot",
+ "rand_chacha",
  "rand_core",
  "ring",
  "socket2",
@@ -407,7 +408,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -785,21 +786,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.63"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
@@ -1012,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1074,7 +1094,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1137,7 +1157,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1465,6 +1485,26 @@ dependencies = [
  "rand_core",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/boringtun/Cargo.toml
+++ b/boringtun/Cargo.toml
@@ -37,6 +37,7 @@ x25519-dalek = { version = "2.0.1", features = [
     "static_secrets",
 ] }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
+rand_chacha = { version = "0.3", default-features = false }
 chacha20poly1305 = "0.10.0-pre.1"
 aead = "0.5.0-pre.2"
 blake2 = "0.10"

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -334,7 +334,9 @@ impl Device {
             keepalive,
             next_index,
             None,
-        );
+            0, 0, 0, 0, 0, 0, 0, 0,
+        )
+        .expect("default obfuscation ranges must not conflict");
 
         let peer = Peer::new(tunn, next_index, endpoint, allowed_ips, preshared_key);
 

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -37,6 +37,7 @@ use std::thread::JoinHandle;
 
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::parse_handshake_anon;
+use crate::noise::handshake::ObfuscationRanges;
 use crate::noise::rate_limiter::RateLimiter;
 use crate::noise::{Packet, Tunn, TunnResult};
 use crate::x25519;
@@ -612,6 +613,8 @@ impl Device {
                     let packet = &t.src_buf[..packet_len];
                     // The rate limiter initially checks mac1 and mac2, and optionally asks to send a cookie
                     let parsed_packet = match rate_limiter.verify_packet(
+                        ObfuscationRanges::default(),
+                        &mut OsRng,
                         Some(addr.as_socket().unwrap().ip()),
                         packet,
                         &mut t.dst_buf,

--- a/boringtun/src/ffi/mod.rs
+++ b/boringtun/src/ffi/mod.rs
@@ -34,7 +34,11 @@ thread_local! {
 
 fn set_last_error(msg: &str) {
     LAST_ERROR.with(|e| {
-        *e.borrow_mut() = CString::new(msg).ok();
+        *e.borrow_mut() = Some(
+            CString::new(msg).unwrap_or_else(|_| {
+                CString::new("Invalid error message (contains null byte)").unwrap()
+            }),
+        );
     });
 }
 

--- a/boringtun/src/jni.rs
+++ b/boringtun/src/jni.rs
@@ -161,6 +161,7 @@ pub unsafe extern "C" fn create_new_tunnel(
         preshared_key,
         keep_alive as u16,
         index as u32,
+        0, 0, 0, 0, 0, 0, 0, 0,
     );
 
     if tunnel.is_null() {

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -8,7 +8,7 @@ pub mod rate_limiter;
 mod session;
 mod timers;
 
-use handshake::Obfuscation;
+use handshake::ObfuscationRanges;
 
 use crate::noise::errors::WireGuardError;
 use crate::noise::handshake::Handshake;
@@ -127,7 +127,7 @@ pub enum Packet<'a> {
 
 impl Tunn {
     #[inline(always)]
-    pub fn parse_incoming_packet(obf: Obfuscation, src: &[u8]) -> Result<Packet, WireGuardError> {
+    pub fn parse_incoming_packet(obf: ObfuscationRanges, src: &[u8]) -> Result<Packet, WireGuardError> {
         if src.len() < 4 {
             return Err(WireGuardError::InvalidPacket);
         }
@@ -136,26 +136,26 @@ impl Tunn {
         let packet_type = u32::from_le_bytes(src[0..4].try_into().unwrap());
 
         Ok(match (packet_type, src.len()) {
-            (v, HANDSHAKE_INIT_SZ) if v == obf.obf_init => Packet::HandshakeInit(HandshakeInit {
+            (v, HANDSHAKE_INIT_SZ) if obf.matches_h1(v) => Packet::HandshakeInit(HandshakeInit {
                 sender_idx: u32::from_le_bytes(src[4..8].try_into().unwrap()),
                 unencrypted_ephemeral: <&[u8; 32] as TryFrom<&[u8]>>::try_from(&src[8..40])
                     .expect("length already checked above"),
                 encrypted_static: &src[40..88],
                 encrypted_timestamp: &src[88..116],
             }),
-            (v, HANDSHAKE_RESP_SZ) if v == obf.obf_resp => Packet::HandshakeResponse(HandshakeResponse {
+            (v, HANDSHAKE_RESP_SZ) if obf.matches_h2(v) => Packet::HandshakeResponse(HandshakeResponse {
                 sender_idx: u32::from_le_bytes(src[4..8].try_into().unwrap()),
                 receiver_idx: u32::from_le_bytes(src[8..12].try_into().unwrap()),
                 unencrypted_ephemeral: <&[u8; 32] as TryFrom<&[u8]>>::try_from(&src[12..44])
                     .expect("length already checked above"),
                 encrypted_nothing: &src[44..60],
             }),
-            (v, COOKIE_REPLY_SZ) if v == obf.obf_cookie => Packet::PacketCookieReply(PacketCookieReply {
+            (v, COOKIE_REPLY_SZ) if obf.matches_h3(v) => Packet::PacketCookieReply(PacketCookieReply {
                 receiver_idx: u32::from_le_bytes(src[4..8].try_into().unwrap()),
                 nonce: &src[8..32],
                 encrypted_cookie: &src[32..64],
             }),
-            (v, DATA_OVERHEAD_SZ..=std::usize::MAX) if v == obf.obf_data => Packet::PacketData(PacketData {
+            (v, DATA_OVERHEAD_SZ..=std::usize::MAX) if obf.matches_h4(v) => Packet::PacketData(PacketData {
                 receiver_idx: u32::from_le_bytes(src[4..8].try_into().unwrap()),
                 counter: u64::from_le_bytes(src[8..16].try_into().unwrap()),
                 encrypted_encapsulated_packet: &src[16..],
@@ -200,25 +200,32 @@ impl Tunn {
         persistent_keepalive: Option<u16>,
         index: u32,
         rate_limiter: Option<Arc<RateLimiter>>,
-        obf_init: u32,
-        obf_resp: u32,
-        obf_cookie: u32,
-        obf_data: u32,
-    ) -> Self {
+        h1_init_start: u32,
+        h1_init_end: u32,
+        h2_resp_start: u32,
+        h2_resp_end: u32,
+        h3_cookie_start: u32,
+        h3_cookie_end: u32,
+        h4_data_start: u32,
+        h4_data_end: u32,
+    ) -> Result<Self, String> {
         let static_public = x25519::PublicKey::from(&static_private);
 
-        Tunn {
+        let obf = ObfuscationRanges::new(
+            h1_init_start, h1_init_end,
+            h2_resp_start, h2_resp_end,
+            h3_cookie_start, h3_cookie_end,
+            h4_data_start, h4_data_end,
+        )?;
+
+        Ok(Tunn {
             handshake: Handshake::new(
                 static_private,
                 static_public,
                 peer_static_public,
-                //index << 8,
                 index,
                 preshared_key,
-                obf_init,
-                obf_resp,
-                obf_cookie,
-                obf_data,
+                obf,
             ),
             sessions: Default::default(),
             current: Default::default(),
@@ -231,7 +238,7 @@ impl Tunn {
             rate_limiter: rate_limiter.unwrap_or_else(|| {
                 Arc::new(RateLimiter::new(&static_public, PEER_HANDSHAKE_RATE_LIMIT))
             }),
-        }
+        })
     }
 
     /// Update the private key and clear existing sessions
@@ -613,9 +620,11 @@ mod tests {
         let their_public_key = x25519_dalek::PublicKey::from(&their_secret_key);
         let their_idx = OsRng.next_u32();
 
-        let my_tun = Tunn::new(my_secret_key, their_public_key, None, None, my_idx, None);
+        let my_tun = Tunn::new(my_secret_key, their_public_key, None, None, my_idx, None,
+            0, 0, 0, 0, 0, 0, 0, 0).unwrap();
 
-        let their_tun = Tunn::new(their_secret_key, my_public_key, None, None, their_idx, None);
+        let their_tun = Tunn::new(their_secret_key, my_public_key, None, None, their_idx, None,
+            0, 0, 0, 0, 0, 0, 0, 0).unwrap();
 
         (my_tun, their_tun)
     }
@@ -696,7 +705,7 @@ mod tests {
         } else {
             unreachable!();
         };
-        let packet = Tunn::parse_incoming_packet(packet_data).unwrap();
+        let packet = Tunn::parse_incoming_packet(tun.handshake.obf, packet_data).unwrap();
         assert!(matches!(packet, Packet::HandshakeInit(_)));
     }
 
@@ -770,7 +779,7 @@ mod tests {
         let (mut my_tun, _their_tun) = create_two_tuns();
 
         let init = create_handshake_init(&mut my_tun);
-        let packet = Tunn::parse_incoming_packet(&init).unwrap();
+        let packet = Tunn::parse_incoming_packet(my_tun.handshake.obf, &init).unwrap();
         assert!(matches!(packet, Packet::HandshakeInit(_)));
 
         mock_instant::MockClock::advance(REKEY_TIMEOUT);
@@ -801,5 +810,162 @@ mod tests {
             unreachable!();
         };
         assert_eq!(sent_packet_buf, recv_packet_buf);
+    }
+
+    // ---- ObfuscationRanges unit tests ----
+
+    use crate::noise::handshake::{ObfuscationRanges, TagRange};
+
+    #[test]
+    fn obf_default_mapping() {
+        // (0,0) for all ranges yields default WG constants
+        let obf = ObfuscationRanges::new(0, 0, 0, 0, 0, 0, 0, 0).unwrap();
+        assert_eq!(obf.h1_init, TagRange { start: 1, end: 1 });
+        assert_eq!(obf.h2_resp, TagRange { start: 2, end: 2 });
+        assert_eq!(obf.h3_cookie, TagRange { start: 3, end: 3 });
+        assert_eq!(obf.h4_data, TagRange { start: 4, end: 4 });
+    }
+
+    #[test]
+    fn obf_fixed_mapping() {
+        // start=end yields a single-element range
+        let obf = ObfuscationRanges::new(10, 10, 20, 20, 30, 30, 40, 40).unwrap();
+        assert_eq!(obf.h1_init, TagRange { start: 10, end: 10 });
+        assert_eq!(obf.h2_resp, TagRange { start: 20, end: 20 });
+        assert_eq!(obf.h3_cookie, TagRange { start: 30, end: 30 });
+        assert_eq!(obf.h4_data, TagRange { start: 40, end: 40 });
+    }
+
+    #[test]
+    fn obf_back_compat_single_value() {
+        // (start, 0) where start != 0 => [start..=start]
+        let obf = ObfuscationRanges::new(10, 0, 20, 0, 30, 0, 40, 0).unwrap();
+        assert_eq!(obf.h1_init, TagRange { start: 10, end: 10 });
+        assert_eq!(obf.h2_resp, TagRange { start: 20, end: 20 });
+        assert_eq!(obf.h3_cookie, TagRange { start: 30, end: 30 });
+        assert_eq!(obf.h4_data, TagRange { start: 40, end: 40 });
+    }
+
+    #[test]
+    fn obf_overlap_detection() {
+        // H1 [10..20] and H4 [20..30] overlap at boundary 20
+        let result = ObfuscationRanges::new(10, 20, 100, 110, 200, 210, 20, 30);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("H1"), "Error should mention H1: {msg}");
+        assert!(msg.contains("H4"), "Error should mention H4: {msg}");
+        assert!(msg.contains("overlaps"), "Error should mention overlaps: {msg}");
+    }
+
+    #[test]
+    fn obf_overlap_detection_h2_h3() {
+        let result = ObfuscationRanges::new(10, 20, 50, 60, 55, 65, 100, 110);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("H2"), "Error should mention H2: {msg}");
+        assert!(msg.contains("H3"), "Error should mention H3: {msg}");
+    }
+
+    #[test]
+    fn obf_start_greater_than_end() {
+        let result = ObfuscationRanges::new(20, 10, 100, 110, 200, 210, 300, 310);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("start"), "Error should mention start: {msg}");
+    }
+
+    #[test]
+    fn obf_incoming_accept_reject() {
+        let obf = ObfuscationRanges::new(10, 20, 30, 40, 50, 60, 70, 80).unwrap();
+
+        // H1: packet with correct range and size should be accepted
+        let mut init_packet = vec![0u8; HANDSHAKE_INIT_SZ];
+        init_packet[0..4].copy_from_slice(&15u32.to_le_bytes()); // within [10..20]
+        let result = Tunn::parse_incoming_packet(obf, &init_packet);
+        assert!(matches!(result, Ok(Packet::HandshakeInit(_))));
+
+        // H1: tag outside range but correct size should be rejected
+        init_packet[0..4].copy_from_slice(&25u32.to_le_bytes()); // outside [10..20]
+        let result = Tunn::parse_incoming_packet(obf, &init_packet);
+        assert!(matches!(result, Err(WireGuardError::InvalidPacket)));
+
+        // H2: packet with correct range and size
+        let mut resp_packet = vec![0u8; HANDSHAKE_RESP_SZ];
+        resp_packet[0..4].copy_from_slice(&35u32.to_le_bytes()); // within [30..40]
+        let result = Tunn::parse_incoming_packet(obf, &resp_packet);
+        assert!(matches!(result, Ok(Packet::HandshakeResponse(_))));
+
+        // H2: tag outside range
+        resp_packet[0..4].copy_from_slice(&45u32.to_le_bytes()); // outside [30..40]
+        let result = Tunn::parse_incoming_packet(obf, &resp_packet);
+        assert!(matches!(result, Err(WireGuardError::InvalidPacket)));
+
+        // H3: cookie reply
+        let mut cookie_packet = vec![0u8; COOKIE_REPLY_SZ];
+        cookie_packet[0..4].copy_from_slice(&55u32.to_le_bytes()); // within [50..60]
+        let result = Tunn::parse_incoming_packet(obf, &cookie_packet);
+        assert!(matches!(result, Ok(Packet::PacketCookieReply(_))));
+
+        cookie_packet[0..4].copy_from_slice(&65u32.to_le_bytes()); // outside [50..60]
+        let result = Tunn::parse_incoming_packet(obf, &cookie_packet);
+        assert!(matches!(result, Err(WireGuardError::InvalidPacket)));
+
+        // H4: data packet (minimum size)
+        let mut data_packet = vec![0u8; DATA_OVERHEAD_SZ];
+        data_packet[0..4].copy_from_slice(&75u32.to_le_bytes()); // within [70..80]
+        let result = Tunn::parse_incoming_packet(obf, &data_packet);
+        assert!(matches!(result, Ok(Packet::PacketData(_))));
+
+        data_packet[0..4].copy_from_slice(&85u32.to_le_bytes()); // outside [70..80]
+        let result = Tunn::parse_incoming_packet(obf, &data_packet);
+        assert!(matches!(result, Err(WireGuardError::InvalidPacket)));
+    }
+
+    #[test]
+    fn obf_outgoing_random_within_bounds() {
+        let obf = ObfuscationRanges::new(100, 200, 300, 400, 500, 600, 700, 800).unwrap();
+        for _ in 0..1000 {
+            let v = obf.random_h1();
+            assert!(v >= 100 && v <= 200, "H1 random {v} out of range [100..200]");
+            let v = obf.random_h2();
+            assert!(v >= 300 && v <= 400, "H2 random {v} out of range [300..400]");
+            let v = obf.random_h3();
+            assert!(v >= 500 && v <= 600, "H3 random {v} out of range [500..600]");
+            let v = obf.random_h4();
+            assert!(v >= 700 && v <= 800, "H4 random {v} out of range [700..800]");
+        }
+    }
+
+    #[test]
+    fn obf_fixed_range_random_is_constant() {
+        let obf = ObfuscationRanges::new(42, 42, 99, 99, 7, 7, 13, 13).unwrap();
+        for _ in 0..100 {
+            assert_eq!(obf.random_h1(), 42);
+            assert_eq!(obf.random_h2(), 99);
+            assert_eq!(obf.random_h3(), 7);
+            assert_eq!(obf.random_h4(), 13);
+        }
+    }
+
+    #[test]
+    fn obf_ranges_handshake_roundtrip() {
+        // Verify that tunnels with matching range config can handshake
+        let my_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let my_public_key = x25519_dalek::PublicKey::from(&my_secret_key);
+        let my_idx = OsRng.next_u32();
+
+        let their_secret_key = x25519_dalek::StaticSecret::random_from_rng(OsRng);
+        let their_public_key = x25519_dalek::PublicKey::from(&their_secret_key);
+        let their_idx = OsRng.next_u32();
+
+        let mut my_tun = Tunn::new(my_secret_key, their_public_key, None, None, my_idx, None,
+            100, 200, 300, 400, 500, 600, 700, 800).unwrap();
+        let mut their_tun = Tunn::new(their_secret_key, my_public_key, None, None, their_idx, None,
+            100, 200, 300, 400, 500, 600, 700, 800).unwrap();
+
+        let init = create_handshake_init(&mut my_tun);
+        let resp = create_handshake_response(&mut their_tun, &init);
+        let keepalive = parse_handshake_resp(&mut my_tun, &resp);
+        parse_keepalive(&mut their_tun, &keepalive);
     }
 }

--- a/boringtun/src/noise/rate_limiter.rs
+++ b/boringtun/src/noise/rate_limiter.rs
@@ -1,4 +1,4 @@
-use super::handshake::{b2s_hash, b2s_keyed_mac_16, b2s_keyed_mac_16_2, b2s_mac_24, Obfuscation};
+use super::handshake::{b2s_hash, b2s_keyed_mac_16, b2s_keyed_mac_16_2, b2s_mac_24, ObfuscationRanges};
 use crate::noise::handshake::{LABEL_COOKIE, LABEL_MAC1};
 use crate::noise::{HandshakeInit, HandshakeResponse, Packet, Tunn, TunnResult, WireGuardError};
 
@@ -114,7 +114,7 @@ impl RateLimiter {
 
     pub(crate) fn format_cookie_reply<'a>(
         &self,
-        obf: Obfuscation,
+        obf: ObfuscationRanges,
         idx: u32,
         cookie: Cookie,
         mac1: &[u8],
@@ -131,7 +131,7 @@ impl RateLimiter {
 
         // msg.message_type = 3
         // msg.reserved_zero = { 0, 0, 0 }
-        message_type.copy_from_slice(&obf.obf_cookie.to_le_bytes());
+        message_type.copy_from_slice(&obf.random_h3().to_le_bytes());
         // msg.receiver_index = little_endian(initiator.sender_index)
         receiver_index.copy_from_slice(&idx.to_le_bytes());
         nonce.copy_from_slice(&self.nonce()[..]);
@@ -153,7 +153,7 @@ impl RateLimiter {
     /// Verify the MAC fields on the datagram, and apply rate limiting if needed
     pub fn verify_packet<'a, 'b>(
         &self,
-        obf: Obfuscation,
+        obf: ObfuscationRanges,
         src_addr: Option<IpAddr>,
         src: &'a [u8],
         dst: &'b mut [u8],

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -126,6 +126,15 @@ struct wireguard_tunnel *new_tunnel(const char *static_private,
                                     uint32_t h4_data_start,    // H4 (transport data) inclusive range start
                                     uint32_t h4_data_end);     // H4 (transport data) inclusive range end
 
+// Returns a pointer to the last error message from new_tunnel, or NULL if
+// no error is stored.  The pointer is valid until the next call to
+// new_tunnel on the same thread, or until freed with last_tunnel_error_free.
+const char *last_tunnel_error();
+
+// Frees the last error string stored by new_tunnel.  After this call
+// last_tunnel_error will return NULL until the next failure.
+void last_tunnel_error_free();
+
 // Deallocate the tunnel
 void tunnel_free(struct wireguard_tunnel *);
 

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -82,7 +82,7 @@ bool set_logging_function(void (*log_func)(const char *));
 ///
 /// Each WireGuard packet type has an associated 4-byte "message type" tag.
 /// The h1-h4 start/end pairs let you override these tags with inclusive
-/// ranges `[start..end]`.  On outgoing packets a value is chosen uniformly
+/// ranges [start, end].  On outgoing packets a value is chosen uniformly
 /// at random from the range; on incoming packets any value within the range
 /// is accepted for that packet type.
 ///
@@ -91,14 +91,14 @@ bool set_logging_function(void (*log_func)(const char *));
 /// | start | end   | Resolved range                              |
 /// |-------|-------|---------------------------------------------|
 /// | 0     | 0     | Default WireGuard constant (1, 2, 3, or 4)  |
-/// | S > 0 | 0     | Fixed value [S..S]  (back-compat shorthand) |
-/// | S     | E >= S| Custom inclusive range [S..E]                |
+/// | S > 0 | 0     | Fixed value [S, S]  (back-compat shorthand) |
+/// | S     | E >= S| Custom inclusive range [S, E]                |
 /// | S     | E < S | **Invalid** - returns NULL                   |
 ///
 /// **Non-overlap requirement:**
 ///
 /// The four resolved ranges must not overlap (including at boundaries).
-/// For example H1=[10..20] and H4=[20..30] is rejected because value 20
+/// For example H1=[10, 20] and H4=[20, 30] is rejected because value 20
 /// belongs to both.  On conflict the function returns NULL.
 ///
 /// **Quick-start examples:**

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -75,14 +75,18 @@ bool set_logging_function(void (*log_func)(const char *));
 
 // Allocate a new tunnel
 struct wireguard_tunnel *new_tunnel(const char *static_private,
-                                    const char *server_static_public,
-                                    const char *preshared_key,
-                                    uint16_t keep_alive,  // Keep alive interval in seconds
-                                    uint32_t index,       // The 24bit index prefix to be used for session indexes
-                                    uint32_t obf_init,    // The 32bit obfuscation init value
-                                    uint32_t obf_resp,    // The 32bit obfuscation response value
-                                    uint32_t obf_cookie,  // The 32bit obfuscation cookie value
-                                    uint32_t obf_data);   // The 32bit obfuscation data value
+const char *server_static_public,
+const char *preshared_key,
+uint16_t keep_alive,  // Keep alive interval in seconds
+uint32_t index,       // The 24bit index prefix to be used for session indexes
+uint32_t h1_init_start,   // H1 (handshake init) range start
+uint32_t h1_init_end,     // H1 (handshake init) range end
+uint32_t h2_resp_start,   // H2 (handshake response) range start
+uint32_t h2_resp_end,     // H2 (handshake response) range end
+uint32_t h3_cookie_start, // H3 (cookie reply) range start
+uint32_t h3_cookie_end,   // H3 (cookie reply) range end
+uint32_t h4_data_start,   // H4 (data) range start
+uint32_t h4_data_end);    // H4 (data) range end
 
 // Deallocate the tunnel
 void tunnel_free(struct wireguard_tunnel *);

--- a/boringtun/src/wireguard_ffi.h
+++ b/boringtun/src/wireguard_ffi.h
@@ -73,20 +73,58 @@ int check_base64_encoded_x25519_key(const char *key);
 /// to be stored then `log_func` needs to create a copy, e.g. `strcpy`.
 bool set_logging_function(void (*log_func)(const char *));
 
-// Allocate a new tunnel
+/// Allocate a new tunnel, returning NULL on failure.
+///
+/// Keys must be valid base64-encoded 32-byte keys.
+/// `preshared_key` may be NULL if no PSK is used.
+///
+/// ## Amnezia obfuscation tag ranges (H1-H4)
+///
+/// Each WireGuard packet type has an associated 4-byte "message type" tag.
+/// The h1-h4 start/end pairs let you override these tags with inclusive
+/// ranges `[start..end]`.  On outgoing packets a value is chosen uniformly
+/// at random from the range; on incoming packets any value within the range
+/// is accepted for that packet type.
+///
+/// **Sentinel rules for each (start, end) pair:**
+///
+/// | start | end   | Resolved range                              |
+/// |-------|-------|---------------------------------------------|
+/// | 0     | 0     | Default WireGuard constant (1, 2, 3, or 4)  |
+/// | S > 0 | 0     | Fixed value [S..S]  (back-compat shorthand) |
+/// | S     | E >= S| Custom inclusive range [S..E]                |
+/// | S     | E < S | **Invalid** - returns NULL                   |
+///
+/// **Non-overlap requirement:**
+///
+/// The four resolved ranges must not overlap (including at boundaries).
+/// For example H1=[10..20] and H4=[20..30] is rejected because value 20
+/// belongs to both.  On conflict the function returns NULL.
+///
+/// **Quick-start examples:**
+///
+///   // Standard WireGuard (no obfuscation):
+///   new_tunnel(priv, pub, NULL, 25, idx, 0,0, 0,0, 0,0, 0,0);
+///
+///   // Fixed Amnezia-style tags (single values):
+///   new_tunnel(priv, pub, NULL, 25, idx, 10,10, 20,20, 30,30, 40,40);
+///
+///   // Random tags from non-overlapping ranges:
+///   new_tunnel(priv, pub, NULL, 25, idx, 100,199, 200,299, 300,399, 400,499);
+///
 struct wireguard_tunnel *new_tunnel(const char *static_private,
-const char *server_static_public,
-const char *preshared_key,
-uint16_t keep_alive,  // Keep alive interval in seconds
-uint32_t index,       // The 24bit index prefix to be used for session indexes
-uint32_t h1_init_start,   // H1 (handshake init) range start
-uint32_t h1_init_end,     // H1 (handshake init) range end
-uint32_t h2_resp_start,   // H2 (handshake response) range start
-uint32_t h2_resp_end,     // H2 (handshake response) range end
-uint32_t h3_cookie_start, // H3 (cookie reply) range start
-uint32_t h3_cookie_end,   // H3 (cookie reply) range end
-uint32_t h4_data_start,   // H4 (data) range start
-uint32_t h4_data_end);    // H4 (data) range end
+                                    const char *server_static_public,
+                                    const char *preshared_key,
+                                    uint16_t keep_alive,       // Keep alive interval in seconds
+                                    uint32_t index,            // The 24bit index prefix for session indexes
+                                    uint32_t h1_init_start,    // H1 (handshake init) inclusive range start
+                                    uint32_t h1_init_end,      // H1 (handshake init) inclusive range end
+                                    uint32_t h2_resp_start,    // H2 (handshake resp) inclusive range start
+                                    uint32_t h2_resp_end,      // H2 (handshake resp) inclusive range end
+                                    uint32_t h3_cookie_start,  // H3 (cookie reply)   inclusive range start
+                                    uint32_t h3_cookie_end,    // H3 (cookie reply)   inclusive range end
+                                    uint32_t h4_data_start,    // H4 (transport data) inclusive range start
+                                    uint32_t h4_data_end);     // H4 (transport data) inclusive range end
 
 // Deallocate the tunnel
 void tunnel_free(struct wireguard_tunnel *);


### PR DESCRIPTION
Replace fixed single-value obfuscation tags with non-overlapping inclusive ranges for each WireGuard packet type (H1: handshake init, H2: handshake response, H3: cookie reply, H4: data).

- Introduce TagRange and ObfuscationRanges types with validation, range matching, and per-packet random tag selection via OsRng
- Update FFI (new_tunnel) to accept 8 start/end u32 params instead of 4
- Validate ranges at tunnel creation: start <= end, no pairwise overlap, with descriptive error messages identifying conflicting ranges
- Incoming packets matched by range containment (length-first discrimination)
- Outgoing packets use uniformly random tag from configured range
- Back-compat: (0,0) maps to default WG constant, (start,0) maps to [start..=start], start=end yields fixed value
- Add unit tests for default/fixed mapping, overlap detection, incoming accept/reject, outgoing bounds, and range-config handshake roundtrip

BREAKING CHANGE: new_tunnel FFI signature changes from 4 obfuscation params (obf_init, obf_resp, obf_cookie, obf_data) to 8 range params (h1_init_start/end, h2_resp_start/end, h3_cookie_start/end, h4_data_start/end). Existing callers passing single values should use start=end=value. Tunn::new now returns Result<Self, String>.