### PR TITLE
cleanup: remove unused fingerprint helper; fix non_fmt_panics warnings

### DIFF
--- a/boringtun/src/noise/imitation/dns.rs
+++ b/boringtun/src/noise/imitation/dns.rs
@@ -95,7 +95,8 @@ mod tests {
         let ids: Vec<u16> = packets.iter().map(|p| be16(&p[0..2])).collect();
         assert!(
             ids[0] != ids[1] && ids[0] != ids[2] && ids[1] != ids[2],
-            "transaction ids must all differ, got {ids:?}"
+            "transaction ids must all differ, got {:?}",
+            ids
         );
     }
 }

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -1207,7 +1207,8 @@ mod tests {
             for _ in 0..pre_handshake_count {
                 assert!(
                     matches!(result, TunnResult::WriteToNetwork(_)),
-                    "expected pre-handshake datagram for protocol={protocol:?}"
+                    "expected pre-handshake datagram for protocol={:?}",
+                    protocol
                 );
                 std::thread::sleep(Duration::from_millis(25));
                 result = my_tun.update_timers(&mut dst);
@@ -1236,7 +1237,10 @@ mod tests {
             let recv_packet_buf = if let TunnResult::WriteToTunnelV4(recv, _addr) = recv {
                 recv
             } else {
-                panic!("expected WriteToTunnelV4 for protocol={protocol:?}, got {recv:?}");
+                panic!(
+                    "expected WriteToTunnelV4 for protocol={:?}, got {:?}",
+                    protocol, recv
+                );
             };
             assert_eq!(sent_packet_buf, recv_packet_buf, "protocol={protocol:?}");
         }

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -1540,11 +1540,12 @@ mod tests {
         let result = ObfuscationRanges::new(10, 20, 100, 110, 200, 210, 20, 30);
         assert!(result.is_err());
         let msg = result.unwrap_err();
-        assert!(msg.contains("H1"), "Error should mention H1: {msg}");
-        assert!(msg.contains("H4"), "Error should mention H4: {msg}");
+        assert!(msg.contains("H1"), "Error should mention H1: {}", msg);
+        assert!(msg.contains("H4"), "Error should mention H4: {}", msg);
         assert!(
             msg.contains("overlaps"),
-            "Error should mention overlaps: {msg}"
+            "Error should mention overlaps: {}",
+            msg
         );
     }
 
@@ -1553,8 +1554,8 @@ mod tests {
         let result = ObfuscationRanges::new(10, 20, 50, 60, 55, 65, 100, 110);
         assert!(result.is_err());
         let msg = result.unwrap_err();
-        assert!(msg.contains("H2"), "Error should mention H2: {msg}");
-        assert!(msg.contains("H3"), "Error should mention H3: {msg}");
+        assert!(msg.contains("H2"), "Error should mention H2: {}", msg);
+        assert!(msg.contains("H3"), "Error should mention H3: {}", msg);
     }
 
     #[test]
@@ -1562,8 +1563,12 @@ mod tests {
         let result = ObfuscationRanges::new(20, 10, 100, 110, 200, 210, 300, 310);
         assert!(result.is_err());
         let msg = result.unwrap_err();
-        assert!(msg.contains("H1"), "Error should identify range H1: {msg}");
-        assert!(msg.contains("start"), "Error should mention start: {msg}");
+        assert!(
+            msg.contains("H1"),
+            "Error should identify range H1: {}",
+            msg
+        );
+        assert!(msg.contains("start"), "Error should mention start: {}", msg);
     }
 
     #[test]
@@ -1621,22 +1626,26 @@ mod tests {
             let v = obf.random_h1(&mut rng);
             assert!(
                 v >= 100 && v <= 200,
-                "H1 random {v} out of range [100..200]"
+                "H1 random {} out of range [100..200]",
+                v
             );
             let v = obf.random_h2(&mut rng);
             assert!(
                 v >= 300 && v <= 400,
-                "H2 random {v} out of range [300..400]"
+                "H2 random {} out of range [300..400]",
+                v
             );
             let v = obf.random_h3(&mut rng);
             assert!(
                 v >= 500 && v <= 600,
-                "H3 random {v} out of range [500..600]"
+                "H3 random {} out of range [500..600]",
+                v
             );
             let v = obf.random_h4(&mut rng);
             assert!(
                 v >= 700 && v <= 800,
-                "H4 random {v} out of range [700..800]"
+                "H4 random {} out of range [700..800]",
+                v
             );
         }
     }

--- a/boringtun/src/noise/quic/fingerprint.rs
+++ b/boringtun/src/noise/quic/fingerprint.rs
@@ -39,14 +39,6 @@ impl Fingerprint {
         v.dedup();
         v
     }
-
-    /// Transport-parameter ids as a sorted set.
-    pub(crate) fn transport_param_set(&self) -> Vec<u64> {
-        let mut v = self.transport_param_ids.clone();
-        v.sort_unstable();
-        v.dedup();
-        v
-    }
 }
 
 fn be16(b: &[u8]) -> u16 {

--- a/boringtun/src/noise/quic/generator.rs
+++ b/boringtun/src/noise/quic/generator.rs
@@ -164,7 +164,8 @@ mod tests {
             let is_curl = fp.key_share_groups == vec![0x001d];
             assert!(
                 is_chrome || is_firefox || is_curl,
-                "random must be a real profile (seed {seed})"
+                "random must be a real profile (seed {})",
+                seed
             );
             seen_curl |= is_curl;
             seen_two_packet |= packets.len() == 2;


### PR DESCRIPTION
Post-merge cleanup of the AmneziaWG protocol-imitation work (PR #5), addressing
the non-blocking review nits.

## Changes
- Remove the never-used `Fingerprint::transport_param_set` helper (no callers).
- Fix all edition-2018 `non_fmt_panics` warnings by passing the values as
  explicit format arguments so the assertion messages actually interpolate:
  - new imitation code: `imitation/dns.rs`, `quic/generator.rs`, and two
    assertions in the amnezia per-protocol handshake test
  - pre-existing H1–H4 obfuscation tests (`obf_overlap_detection*`,
    `obf_start_greater_than_end`, `obf_outgoing_random_within_bounds`)

## Result
`cargo test -p boringtun --features ffi-bindings` is now warning-free except the
inherited `ring::deprecated_constant_time::verify_slices_are_equal` deprecation
(a separate API migration). fmt clean; 72 tests pass.