### PR TITLE
fix(amnezia): strip S4 transport junk before the offset-0 fallback

### DIFF
--- a/boringtun/src/noise/amnezia.rs
+++ b/boringtun/src/noise/amnezia.rs
@@ -393,14 +393,9 @@ impl AmneziaConfig {
             return packet;
         }
 
-        if packet.len() >= DATA_OVERHEAD_SZ
-            && Self::read_tag(packet, 0)
-                .map(|tag| Self::tag_matches(obf, PacketKind::TransportData, tag))
-                .unwrap_or(false)
-        {
-            return packet;
-        }
-
+        // Prefer the configured S4 offset before the plain offset-0 fallback.
+        // S4 junk can itself start with a value inside H4; checking offset 0
+        // first would leave valid padded transport packets unstripped.
         if packet.len() >= junk_size + DATA_OVERHEAD_SZ {
             if Self::read_tag(packet, junk_size)
                 .map(|tag| Self::tag_matches(obf, PacketKind::TransportData, tag))
@@ -408,6 +403,14 @@ impl AmneziaConfig {
             {
                 return &packet[junk_size..];
             }
+        }
+
+        if packet.len() >= DATA_OVERHEAD_SZ
+            && Self::read_tag(packet, 0)
+                .map(|tag| Self::tag_matches(obf, PacketKind::TransportData, tag))
+                .unwrap_or(false)
+        {
+            return packet;
         }
 
         packet
@@ -1227,16 +1230,31 @@ mod tests {
     }
 
     #[test]
-    fn leaves_unpadded_transport_unchanged_when_payload_at_s4_looks_like_h4() {
+    fn leaves_unpadded_transport_unchanged_when_s4_candidate_is_absent() {
         let obf = ObfuscationRanges::default();
         let cfg = AmneziaConfig::new(0, 0, 0, 17);
         let mut data = vec![0xaa; DATA_OVERHEAD_SZ + 32];
         write_tag(&mut data, DATA);
-        write_tag(&mut data[cfg.transport_packet_junk_size as usize..], DATA);
 
         let stripped = cfg.strip_inbound(obf, &data);
 
         assert_eq!(stripped, data.as_slice());
+    }
+
+    #[test]
+    fn strips_padded_transport_when_junk_prefix_also_looks_like_h4() {
+        let obf = ObfuscationRanges::default();
+        let cfg = AmneziaConfig::new(0, 0, 0, 17);
+        let junk_size = cfg.transport_packet_junk_size as usize;
+        let mut data = vec![0xaa; junk_size + DATA_OVERHEAD_SZ + 32];
+
+        write_tag(&mut data, DATA);
+        write_tag(&mut data[junk_size..], DATA);
+        data[junk_size + 4] = 0x42;
+
+        let stripped = cfg.strip_inbound(obf, &data);
+
+        assert_eq!(stripped, &data[junk_size..]);
     }
 
     #[test]


### PR DESCRIPTION
## Bug

`AmneziaConfig::strip_inbound` removed S4 transport-packet junk by checking
**offset 0 before the configured S4 junk offset**. The S4 junk prefix is
random, so its first four bytes can fall inside the configured **H4 range** —
more often the wider H4 is. When that coincidence hit, the offset-0 branch
matched and returned the *whole still-padded* `[junk][real]` datagram instead
of stripping the junk. The receiver then fed a misaligned packet (header +
counter + ciphertext shifted by `junk_size`) to AEAD decryption, which failed
and dropped the packet.

Result: **intermittent, H4-range-dependent transport packet loss** once S4
(`transport_packet_junk_size`) is configured.

## Fix

Check the configured S4 offset first, then fall back to offset 0.

This is deterministically safe: `prepend_outbound` pads **every** transport
packet when `transport_packet_junk_size > 0`, so a conforming peer's real H4
tag is always at offset `junk_size`. Offset 0 stays only as a defensive
fallback for unpadded/short datagrams. The `junk_size == 0` path is unchanged.

## Tests

- New `strips_padded_transport_when_junk_prefix_also_looks_like_h4` reproduces
  the exact bug (junk prefix whose first bytes look like H4 + a real packet at
  the S4 offset) and asserts the junk is stripped.
- The unpadded test is updated to assert the no-S4-candidate fallback.
- `prepend_then_strip_roundtrips_across_configs_and_protocols` still passes.

73/73 tests pass, fmt clean.